### PR TITLE
Add NN Template

### DIFF
--- a/configs/GrokAi/nn-template.yaml
+++ b/configs/GrokAi/nn-template.yaml
@@ -1,0 +1,59 @@
+target_repository:
+  HTTPS: https://github.com/grok-ai/nn-template
+  # OPTIONAL, for some protected repository
+  # username: my-nick
+  # OPTIONAL, paired with the username
+  # password: dont-tell-anyone
+  # OPTIONAL, overrides the user/pass
+  # token: authentication-token
+  # OPTIONAL, checkout a particular branch or a tag
+  checkout: master
+  # OPTIONAL, define installing package extras
+  install_extras: all
+  # OPTIONAL, install additional requirements from a file
+  requirements_file: requirements.txt
+  # copy some  test from the target repository
+  copy_tests:
+    - integrations
+    - tests/__init__.py
+    - tests/helpers
+
+contact:
+  slack:
+    - lucmos
+  email: [luca.moschella94@gmail.com]
+
+# OPTIONAL, running before installing your project
+# WARNING: this is custom for given OS, we do not manage any inter OS compatibility
+before_install:
+  - pip install Cython==3.56
+
+# OPTIONAL, if any installation require some env. variables
+env:
+  HOROVOD_BUILD_ARCH_FLAGS: "-mfma"
+  # HOROVOD_WITHOUT_MXNET: 1
+  # HOROVOD_WITHOUT_TENSORFLOW: 1
+
+dependencies:
+  - name: pytorch-lightning
+    HTTPS: https://github.com/PyTorchLightning/pytorch-lightning.git
+    checkout: release/1.5.x
+    # install_extras: all
+  - name: Cython
+    checkout: 0.29.24
+
+# OPTIONAL, running before installing your project
+# WARNING: this is custom for given OS, we do not manage any inter OS compatibility
+before_test:
+  - wget https://pl-flash-data.s3.amazonaws.com/titanic.zip
+
+testing:
+  dirs:
+    - tests
+  # OPTIONAL, additional pytest arguments
+  pytest_args: --strict
+
+runtimes:
+  - {os: "ubuntu-20.04", python-version: "3.9"}
+  - {os: "macOS-10.15", python-version: "3.7"}
+  - {os: "windows-2019", python-version: "3.8"}


### PR DESCRIPTION
## Before submitting

- [x] Was this discussed/approved via a GitHub issue? [Yes](https://github.com/grok-ai/nn-template/issues/73)
- [x] Did you create/update your **configuration file**? (WIP)
- [ ] Did you **set `runtimes` in config** for GitHub action integration?
- [ ] Did you **add your config to CI** in Azure pipeline (only projects with 100+ GitHub stars)?
- [ ] Are all integration **tests passing**?

## What does this PR do? \[optional\]

Add support for [nn-template](https://github.com/grok-ai/nn-template).

## Did you have fun?

Always 🙃


## Missing

### Cookiecutter integration

The [nn-template](https://github.com/grok-ai/nn-template) uses cookiecutter to generate a parametrized project from a template. 
Thus it is not enough to clone/checkout a repository to obtain a working project.

In [our CI](https://github.com/grok-ai/nn-template/blob/main/.github/workflows/test_suite.yml) we are using the following to: (1) generate the project with cookiecutter and (2) by-pass the interactive setup (with the hacky echo command)

```yaml
      - name: Install Dependencies
        shell: bash -l {0}
        run: |
          pip install cookiecutter
      - name: Generate Repo
        shell: bash -l {0}
        run: |
          echo -e 'n\nn\nn\n' | cookiecutter . --no-input project_name=${{ env.COOKIECUTTER_PROJECT_NAME }}
```

### Dependencies
This project uses a combination of conda and pip, most of the dependencies are specified in  the `setup.cfg` file.

> The idea is that the conda dependencies specified in the [`env.yaml`](https://github.com/grok-ai/nn-template/blob/main/%7B%7B%20cookiecutter.repository_name%20%7D%7D/env.yaml) are part of the "environment" (e.g. enabling the use of the torch docker image), and thus are not dependencies when installing the package.

To configure an environment, thus, there are two options (after changing the working directory to the cookiecutter-generated project):

1. Using `conda`: `conda env create -f env.yaml`
2. Install the package into an existing environment with `pip install ".[dev]"`

I am not sure which is the best option here, if we want to test the development setup I think the *1.* would be more adequate.

### Complete config

Part of the file is still borrowed from the [template config](https://github.com/PyTorchLightning/ecosystem-ci/blob/main/actions/_config.yaml), e.g. the dependencies, runtimes and `before_test` (p.s. the template file indicated in the README as `configs/template.yaml` does not exists anymore).


---

These are the main challenges I see at the moment. Once the environment is active to run the  tests (and maybe the pre-commits) it is enough to:

```bash
pre-commit install
pre-commit run -v --all-files --show-diff-on-failure
pytest -v
```

---

Please feel free to contribute to this PR if you have any spare time! Otherwise I will try to understand better how to solve these problems in the Lightning's ecosystem CI (not in the immediate future though!).

@Borda @rasbt @Flegyas



